### PR TITLE
(#6) Fix column order of alignment strings by changing toposort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: python
 python:
   - 3.6
-  - 3.6
+  - 3.5
   - 3.4
   - 2.7
 

--- a/poagraph.py
+++ b/poagraph.py
@@ -194,9 +194,9 @@ class POAGraph(object):
                     started.remove(nodeID)
                     continue
 
-                successors = [s for s in self.nodedict[nodeID].outEdges.keys()]
-                successors += [s for s in self.nodedict[nodeID].alignedTo]
-                successors = list(set(successors) - completed)
+                successors = [s for s in self.nodedict[nodeID].outEdges.keys() if s not in completed]
+                successors += [s for s in self.nodedict[nodeID].alignedTo if s not in completed]
+                successors = list(set(successors))
                 started.add(nodeID)
                 stack.append(nodeID)
                 stack.extend(successors)

--- a/poagraph.py
+++ b/poagraph.py
@@ -194,7 +194,9 @@ class POAGraph(object):
                     started.remove(nodeID)
                     continue
 
-                successors = [s for s in self.nodedict[nodeID].outEdges.keys() if s not in completed]
+                successors = [s for s in self.nodedict[nodeID].outEdges.keys()]
+                successors += [s for s in self.nodedict[nodeID].alignedTo]
+                successors = list(set(successors) - completed)
                 started.add(nodeID)
                 stack.append(nodeID)
                 stack.extend(successors)
@@ -391,6 +393,7 @@ class POAGraph(object):
         column_index = {}
         current_column = 0
 
+        # go through nodes in toposort order
         ni = self.nodeiterator()
         for node in ni():
             other_columns = [column_index[other] for other in node.alignedTo if other in column_index]

--- a/tests/test_alignment_column_order.py
+++ b/tests/test_alignment_column_order.py
@@ -30,6 +30,22 @@ def generate_poa_graph(sequences):
     return graph
 
 
+def sequences_and_test(sequences, test_sequence):
+    graph = generate_poa_graph(sequences)
+    alignment = seqgraphalignment.SeqGraphAlignment(test_sequence, graph,
+                                                    fastMethod=False,
+                                                    globalAlign=True,
+                                                    matchscore=1,
+                                                    mismatchscore=-1,
+                                                    gapscore=-2)
+
+    graph.incorporateSeqAlignment(alignment, test_sequence, "test")
+    alignments = graph.generateAlignmentStrings()
+
+    result = alignments[-2][1].replace("-","")
+    return graph, result
+
+
 def test_order_of_alignment_case1():
     sequences = ['ATATTGTGTAAGGCACAATTAACA',
                  'ATATTGCAAGGCACAATTCAACA',
@@ -37,18 +53,7 @@ def test_order_of_alignment_case1():
                  'ATGTGCAAGAGCACATAACA']
     test_sequence = "ATATTGCAAGGCACACTAACA"
 
-    graph = generate_poa_graph(sequences)
-    alignment = seqgraphalignment.SeqGraphAlignment(test_sequence, graph,
-                                                    fastMethod=False,
-                                                    globalAlign=True,
-                                                    matchscore=1,
-                                                    mismatchscore=-1,
-                                                    gapscore=-2)
-
-    graph.incorporateSeqAlignment(alignment, test_sequence, "test")
-    alignments = graph.generateAlignmentStrings()
-
-    result = alignments[-2][1].replace("-","")
+    _, result = sequences_and_test(sequences, test_sequence)
     assert result == test_sequence
 
 
@@ -56,15 +61,21 @@ def test_order_of_alignment_case2():
     sequences = ["TTA", "TGC"]
     test_sequence = "TTGC"
 
-    graph = generate_poa_graph(sequences)
-    alignment = seqgraphalignment.SeqGraphAlignment(test_sequence, graph,
-                                                    fastMethod=False,
-                                                    globalAlign=True,
-                                                    matchscore=1,
-                                                    mismatchscore=-1,
-                                                    gapscore=-2)
+    _, result = sequences_and_test(sequences, test_sequence)
+    assert result == test_sequence
 
-    graph.incorporateSeqAlignment(alignment, test_sequence, "test")
-    alignments = graph.generateAlignmentStrings()
-    result = alignments[-2][1].replace("-","")
+
+def test_order_of_alignment_case3():
+    sequences = ["TAGTGAAAGAGGAAAAGAA"]
+    test_sequence = "GCCCAGAAATTCCAGACCAGC"
+
+    _, result = sequences_and_test(sequences, test_sequence)
+    assert result == test_sequence
+
+
+def test_order_of_alignment_case4():
+    sequences = ["CTACTTGGGAGGCTGAGGTGG", "CCACTTGAGTTGAGG", "CTACTTGGGAAGCTAGAGGTGG"]
+    test_sequence = "CTACTTGGGAGGCTGAGGTGG"
+
+    _, result = sequences_and_test(sequences, test_sequence)
     assert result == test_sequence


### PR DESCRIPTION
This PR, when merged, will address #6 in a permanent way by fixing the topological sort of the POAGraph to incorporate aligned-to edges.