### PR TITLE
Updated visjs to 9.0.4 and added a progress indicator during network stabilization

### DIFF
--- a/poagraph.py
+++ b/poagraph.py
@@ -542,6 +542,8 @@ class POAGraph(object):
 
                   <body>
 
+                  <div id="loadingProgress">0%</div>
+
                   <div id="mynetwork"></div>
 
                   <script type="text/javascript">
@@ -559,9 +561,25 @@ class POAGraph(object):
                   };
                   var options = {
                     width: '100%',
-                    height: '800px'
+                    height: '800px',
+                    physics: {
+                        stabilization: {
+                            updateInterval: 10,
+                        }
+                    }
                   };
                   var network = new vis.Network(container, data, options);
+
+                  network.on("stabilizationProgress", function (params) {
+                    document.getElementById("loadingProgress").innerText = Math.round(params.iterations / params.total * 100) + "%";
+                  });
+                  network.once("stabilizationIterationsDone", function () {
+                      document.getElementById("loadingProgress").innerText = "100%";
+                      setTimeout(function () {
+                        document.getElementById("loadingProgress").style.display = "none";
+                      }, 500);
+                  });
+
                 </script>
 
                 </body>

--- a/poagraph.py
+++ b/poagraph.py
@@ -501,7 +501,7 @@ class POAGraph(object):
         for node in ni():
             line = '    {id:'+str(node.ID)+', label: "'+node.base+'"'
             if node.ID in pathdict and count % 5 == 0:
-                line += ', allowedToMoveX: false, x: ' + str(pathdict[node.ID]) + ', y: 0 , allowedToMoveY: true },'
+                line += ', x: ' + str(pathdict[node.ID]) + ', y: 0 , fixed: { x:true, y:false }},'
             else:
                 line += '},'
             lines.append(line)
@@ -537,7 +537,7 @@ class POAGraph(object):
                   <head>
                     <title>POA Graph Alignment</title>
 
-                    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vis/3.11.0/vis.min.js"></script>
+                    <script type="text/javascript" src="https://unpkg.com/vis-network@9.0.4/standalone/umd/vis-network.min.js"></script>
                   </head>
 
                   <body>


### PR DESCRIPTION
Updated visjs to the most recent version and removed 'allowedToMoveX' and 'allowedToMoveY' (no longer valid parameters, but network will still render while allowing movement of both x and y) in favour of the new parameter 'fixed'.

Added a simple % indicator at the top of the html page that is visible only while the network is (invisibly) stabilizing, to give users indication that something is happening and how long they might have to wait.